### PR TITLE
Fix bug with sizeof/length of binary data and wide chars in UTF8 

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -1,17 +1,18 @@
 import DataStructures.OrderedSet
 
 flatten(token) = string(token)
-flatten(token::AbstractString) = token
+flatten(token::Vector{UInt8}) = [token]
+flatten(token::String) = token
 flatten(token::Array) = map(string, token)
 flatten(token::Set) = map(string, collect(token))
 
 # the following doesn't work in Julia v0.5
 # flatten(token::Dict) = map(string, vcat(map(collect, token)...))
 function flatten(token::Dict)
-    r=AbstractString[]
+    r=Union{String, Vector{UInt8}}[]
     for (k,v) in token
-        push!(r, string(k))
-        push!(r, string(v))
+        push!(r, flatten(k))
+        push!(r, flatten(v))
     end
     r
 end

--- a/src/client.jl
+++ b/src/client.jl
@@ -34,20 +34,23 @@ convert_response(::Type{Float64}, response::T) where {T <: AbstractString} = par
 convert_response(::Type{Float64}, response::T) where {T <: Real} = float(response)::Float64
 convert_response(::Type{Bool}, response::AbstractString) = response == "OK" || response == "QUEUED" ? true : false
 convert_response(::Type{Bool}, response::Integer) = response == 1 ? true : false
-convert_response(::Type{Set{AbstractString}}, response) = Set{AbstractString}(response)
-convert_response(::Type{OrderedSet{AbstractString}}, response) = OrderedSet{AbstractString}(response)
+convert_response(::Type{Set{AbstractString}}, response::Array) = Set{AbstractString}(String(r) for r in response)
+convert_response(::Type{OrderedSet{AbstractString}}, response) = OrderedSet{AbstractString}(String(r) for r in response)
 
 function convert_response(::Type{Dict{AbstractString, AbstractString}}, response)
     iseven(length(response)) || throw(ClientException("Response could not be converted to Dict"))
     retdict = Dict{AbstractString, AbstractString}()
     for i=1:2:length(response)
-        retdict[response[i]] = response[i+1]
+        retdict[String(response[i])] = String(response[i+1])
     end
     retdict
 end
 
+function convert_eval_response(::Any, response::Array)
+    return [String(r) for r in response]
+end
 function convert_eval_response(::Any, response)
-    return response
+    return String(response)
 end
 
 # import Base: ==
@@ -60,7 +63,7 @@ convert_response(::Type{Integer}, response) = response
 function convert_response(::Type{Array{AbstractString, 1}}, response)
     r = Array{AbstractString, 1}()
     for item in response
-        push!(r, item)
+        push!(r, String(item))
     end
     r
 end
@@ -92,6 +95,9 @@ function convert_response(::Type{Array{Union{T, Nothing}, 1}}, response) where {
    else
         r = Array{Union{T, Nothing}, 1}()
         for item in response
+            if !isnothing(item)
+                item = String(item)
+            end
             push!(r, item)
         end
         r

--- a/src/client.jl
+++ b/src/client.jl
@@ -95,7 +95,7 @@ function convert_response(::Type{Array{Union{T, Nothing}, 1}}, response) where {
    else
         r = Array{Union{T, Nothing}, 1}()
         for item in response
-            if !isnothing(item)
+            if item !== nothing
                 item = String(item)
             end
             push!(r, item)

--- a/src/client.jl
+++ b/src/client.jl
@@ -140,6 +140,7 @@ function subscription_loop(conn::SubscriptionConnection, err_callback::Function)
         try
             l = getline(conn.socket)
             reply = parseline(l, conn.socket)
+            reply = convert_reply(reply)
             message = SubscriptionMessage(reply)
             if message.message_type == SubscriptionMessageType.Message
                 conn.callbacks[message.channel](message.message)

--- a/src/connection.jl
+++ b/src/connection.jl
@@ -113,7 +113,3 @@ end
 function is_connected(conn::RedisConnectionBase)
     conn.socket.status == StatusActive || conn.socket.status == StatusOpen || conn.socket.status == StatusPaused
 end
-
-function send_command(conn::RedisConnectionBase, command::AbstractString)
-    write(conn.socket, command)
-end

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -7,10 +7,11 @@ function getline(s::TCPSocket)
     return l
 end
 
+convert_reply(reply::Array{UInt8}) = String(reply)
+convert_reply(reply::Array) = [convert_reply(r) for r in reply]
+convert_reply(x) = x
+
 function read_reply(conn::RedisConnectionBase)
-    convert_reply(reply::Array{UInt8}) = String(reply)
-    convert_reply(reply::Array) = [convert_reply(r) for r in reply]
-    convert_reply(x) = x
     l = getline(conn.socket)
     reply = parseline(l, conn.socket)
     convert_reply(reply)

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -22,7 +22,7 @@ function parse_bulk_string(s::TCPSocket, slen::Int)
             "Bulk string read error: expected $len bytes; received $(length(b))"
         ))
     else
-        return String(b[1:end-2])
+        return resize!(b, slen)
     end
 end
 

--- a/src/parser.jl
+++ b/src/parser.jl
@@ -8,9 +8,12 @@ function getline(s::TCPSocket)
 end
 
 function read_reply(conn::RedisConnectionBase)
+    convert_reply(reply::Array{UInt8}) = String(reply)
+    convert_reply(reply::Array) = [convert_reply(r) for r in reply]
+    convert_reply(x) = x
     l = getline(conn.socket)
     reply = parseline(l, conn.socket)
-    return reply
+    convert_reply(reply)
 end
 
 parse_error(l::AbstractString) = throw(ServerException(l))
@@ -79,7 +82,6 @@ function pack_command(io::IO, command::Vector)
     for token in command
         b += write_token(io, token)
     end
-
     b
 end
 


### PR DESCRIPTION
Should use sizeof instead of length when sending data over the wire. Also
avoided some intermediate allocations by writing to the stream directly.

This fixes a bug where Redis drops one or more bytes because we report the wrong data size. Also if we have a byte array we probably don't want to convert it to String unnecessarily. Finally I had to change a couple of imports of v1.0.3

This might introduce some regressions hence WIP, but I will post it now in case someone runs into the same bug.