### PR TITLE
SubscriptionConnection functions

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -172,6 +172,9 @@ macro redisfunction(command::AbstractString, ret_type, args...)
                 execute_command_without_reply(conn, flatten_command($(command...), $(args...)))
                 conn.num_commands += 1
             end
+            function $(func_name)(conn::SubscriptionConnection, $(args...))
+                execute_command_without_reply(conn, flatten_command($(command...), $(args...)))
+            end
         end
     else
         return quote


### PR DESCRIPTION
If the database is different from 0, due to  [this line](https://github.com/JuliaDatabases/Redis.jl/blob/b37244919af77125122d0ff73027d46ed8d47873/src/connection.jl#L105)

`open_subscription` gives the following error

     MethodError: no method matching select(::Redis.SubscriptionConnection, ::Int64)

I added the `SubscriptionConnection` datatype to the `redisfunction` macro to have that function available. 
    