### PR TITLE
Update readme badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,6 @@
 # Redis.jl
 
-
-[![Build Status](https://travis-ci.org/jkaye2012/Redis.jl.svg?branch=master)](https://travis-ci.org/jkaye2012/Redis.jl) [![Coverage Status](https://coveralls.io/repos/github/merl-dev/Redis.jl/badge.svg?branch=master)](https://coveralls.io/github/merl-dev/Redis.jl?branch=master)  [![DataFrames](http://pkg.julialang.org/badges/Redis_0.4.svg)](http://pkg.julialang.org/?pkg=Redis&ver=0.4) [![DataFrames](http://pkg.julialang.org/badges/Redis_0.5.svg)](http://pkg.julialang.org/?pkg=Redis&ver=0.5)
-
+[![Build Status](https://travis-ci.org/JuliaDatabases/Redis.jl.svg?branch=master)](https://travis-ci.org/JuliaDatabases/Redis.jl) 
 
 
 Redis.jl is a fully-featured Redis client for the Julia programming language. The implementation is an attempt at an easy to understand, minimalistic API that mirrors actual Redis commands as closely as possible.


### PR DESCRIPTION
Update the travis-ci link to the JuliaDatabases org and remove the badges that are no longer valid