### PR TITLE
fix subscription callback invoke and pubsub tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,11 +116,13 @@ publish(conn, "channel", "hello, world!")
 
 Subscriptions are handled using the `SubscriptionConnection`. Similar to the `TransactionConnection`, the `SubscriptionConnection` is constructed from an existing `RedisConnection`. Once created, the `SubscriptionConnection` maintains a simple event loop that will call the user's defined function whenever a message is received on the specified channel.
 
+If the `subscribe_data` method is used for subscription then the callback function will be passed the `message` field of `SubscriptionMessage` instance. If the `subscribe` method is used for subscription, the callback will be passed a `SubscriptionMessage` directly, which contains the channel, message type and key as well. 
+
 ```julia
 x = Any[]
 f(y) = push!(x, y)
 sub = open_subscription(conn)
-subscribe(sub, "baz", f)
+subscribe_data(sub, "baz", f)
 publish(conn, "baz", "foobar")
 x # Returns ["foobar"]
 ```
@@ -129,9 +131,9 @@ Multiple channels can be subscribed together by providing a `Dict{String, Functi
 
 ```julia
 x = Any[]
-f(y::SubscriptionMessage) = push!(x, y)
+f(y::SubscriptionMessage) = push!(x, y.message)
 sub = open_subscription(conn)
-d = Dict{String, Function}({"baz" => f, "bar" => println})
+d = Dict{String, Function}({"baz" => f, "bar" => y->println(y.message)})
 subscribe(sub, d)
 publish(conn, "baz", "foobar")
 x # Returns ["foobar"]

--- a/src/Redis.jl
+++ b/src/Redis.jl
@@ -45,7 +45,7 @@ export discard, exec, multi, unwatch, watch
 # Scripting commands
 export evalscript, evalsha, script_exists, script_flush, script_kill, script_load
 # PubSub commands
-export subscribe, publish, psubscribe, punsubscribe, unsubscribe
+export subscribe, subscribe_data, publish, psubscribe, punsubscribe, unsubscribe
 # Server commands
 export bgrewriteaof, bgsave, client_list, client_id, client_pause, client_setname, cluster_slots,
        command, command_count, command_info, config_get, config_resetstat, config_rewrite,

--- a/src/client.jl
+++ b/src/client.jl
@@ -165,9 +165,9 @@ function subscription_loop(conn::SubscriptionConnection, err_callback::Function)
             reply = convert_reply(reply)
             message = SubscriptionMessage(reply)
             if message.message_type == SubscriptionMessageType.Message
-                conn.callbacks[message.channel](message.message)
+                conn.callbacks[message.channel](message)
             elseif message.message_type == SubscriptionMessageType.Pmessage
-                conn.pcallbacks[message.channel](message.message)
+                conn.pcallbacks[message.channel](message)
             end
         catch err
             err_callback(err)

--- a/src/client.jl
+++ b/src/client.jl
@@ -165,9 +165,9 @@ function subscription_loop(conn::SubscriptionConnection, err_callback::Function)
             reply = convert_reply(reply)
             message = SubscriptionMessage(reply)
             if message.message_type == SubscriptionMessageType.Message
-                conn.callbacks[message.channel](message)
+                conn.callbacks[message.channel](message.message)
             elseif message.message_type == SubscriptionMessageType.Pmessage
-                conn.pcallbacks[message.channel](message)
+                conn.pcallbacks[message.channel](message.message)
             end
         catch err
             err_callback(err)

--- a/test/redis_tests.jl
+++ b/test/redis_tests.jl
@@ -396,7 +396,7 @@ end
         return nothing
     end
     x = Any[]
-    function f(y::String)
+    function f(y::AbstractString)
         push!(x, y)
     end
     subs = open_subscription(conn, handleException) #handleException is called when an exception occurs

--- a/test/redis_tests.jl
+++ b/test/redis_tests.jl
@@ -400,8 +400,8 @@ end
         push!(x, y)
     end
     subs = open_subscription(conn, handleException) #handleException is called when an exception occurs
-    subscribe(subs, "channel", f)
-    subscribe(subs, "duplicate", f)
+    subscribe_data(subs, "channel", f)
+    subscribe(subs, "duplicate", y->f(y.message))
     @test publish(conn, "channel", "hello, world!") > 0 #Number of connected clients returned
     @test publish(conn, "channel", "Okay, bye!") > 0 #Number of connected clients returned
     sleep(2)


### PR DESCRIPTION
The subscription look callbacks were getting invoked with the `SubscriptionMessage` struct. But the docs do not mention that, and seem to suggest that the callback would receive the actual message, which seems natural. The callbacks in tests seem to be expecting the actual message too.

Updated the callback invocation to pass the actual message instead of `SubscriptionMessage` struct.