### PR TITLE
Add keys to evalscript

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -213,8 +213,8 @@ end
 
 # Scripting commands
 # TODO: PipelineConnection and TransactionConnection
-function evalscript(conn::RedisConnection, script, numkeys::Integer, args)
-    response = execute_command(conn, flatten_command("eval", script, numkeys, args))
+function evalscript(conn::RedisConnection, script, numkeys::Integer, keys, args)
+    response = execute_command(conn, flatten_command("eval", script, numkeys, keys, args))
     return response
 end
 

--- a/test/redis_tests.jl
+++ b/test/redis_tests.jl
@@ -333,14 +333,15 @@ function redis_tests(conn = RedisConnection())
 
     @testset "Scripting" begin
         script = "return {KEYS[1], KEYS[2], ARGV[1], ARGV[2]}"
-        args = ["key1", "key2", "first", "second"]
-        resp = evalscript(conn, script, 2, args)
-        @test resp == args
+        keys = ["key1", "key2"]
+        args = ["first", "second"]
+        resp = evalscript(conn, script, 2, keys, args)
+        @test resp == vcat(keys, args)
         del(conn, "key1")
 
         script = "return redis.call('set', KEYS[1], 'bar')"
         ky = "foo"
-        resp = evalscript(conn, script, 1, [ky])
+        resp = evalscript(conn, script, 1, [ky], [])
         @test resp == "OK"
         del(conn, ky)
 

--- a/test/redis_tests.jl
+++ b/test/redis_tests.jl
@@ -346,11 +346,11 @@ function redis_tests(conn = RedisConnection())
         del(conn, ky)
 
         script = "return {10,20}"
-        resp = evalscript(conn, script, 0, [])
+        resp = evalscript(conn, script, 0, [], [])
         @test resp == [10, 20]
 
         script = "return"
-        resp = evalscript(conn, script, 0, [])
+        resp = evalscript(conn, script, 0, [], [])
         @test resp === nothing
 
     #@test evalscript(conn, "return {'1','2',{'3','Hello World!'}}", 0, []) == ["1"; "2"; ["3","Hello World!"]]


### PR DESCRIPTION
`evalscript` should take a `keys` argument, according to https://redis.io/docs/latest/commands/eval/