### PR TITLE
allow "nothing" returns for evalscript

### DIFF
--- a/src/client.jl
+++ b/src/client.jl
@@ -46,17 +46,6 @@ function convert_response(::Type{Dict{AbstractString, AbstractString}}, response
     retdict
 end
 
-function convert_eval_response(::Any, response::Array)
-    return [String(r) for r in response]
-end
-function convert_eval_response(::Any, response)
-    if response === nothing
-        return nothing
-    else
-        return String(response)
-    end
-end
-
 # import Base: ==
 # ==(A::Union{T, Nothing}, B::Union{U, Nothing}) where {T<:AbstractString, U<:AbstractString} = A == B
 # ==(A::Union{T, Nothing}, B::Union{U, Nothing}) where {T<:Number, U<:Number} = A == B

--- a/src/client.jl
+++ b/src/client.jl
@@ -50,7 +50,11 @@ function convert_eval_response(::Any, response::Array)
     return [String(r) for r in response]
 end
 function convert_eval_response(::Any, response)
-    return String(response)
+    if response === nothing
+        return nothing
+    else
+        return String(response)
+    end
 end
 
 # import Base: ==

--- a/src/commands.jl
+++ b/src/commands.jl
@@ -215,7 +215,7 @@ end
 # TODO: PipelineConnection and TransactionConnection
 function evalscript(conn::RedisConnection, script, numkeys::Integer, args)
     response = execute_command(conn, flatten_command("eval", script, numkeys, args))
-    convert_eval_response(Any, response)
+    return response
 end
 
 #################################################################

--- a/test/redis_tests.jl
+++ b/test/redis_tests.jl
@@ -344,6 +344,13 @@ function redis_tests(conn = RedisConnection())
         @test resp == "OK"
         del(conn, ky)
 
+        script = "return {10,20}"
+        resp = evalscript(conn, script, 0, [])
+        @test resp == [10, 20]
+
+        script = "return"
+        resp = evalscript(conn, script, 0, [])
+        @test resp === nothing
 
     #@test evalscript(conn, "return {'1','2',{'3','Hello World!'}}", 0, []) == ["1"; "2"; ["3","Hello World!"]]
 


### PR DESCRIPTION
Without this, a method error is thrown when evalscript has an empty return