### PR TITLE
feat: allow evalscript on pipelines & transactions

### DIFF
--- a/src/commands.jl
+++ b/src/commands.jl
@@ -212,8 +212,7 @@ end
 @redisfunction "watch" Bool key keys...
 
 # Scripting commands
-# TODO: PipelineConnection and TransactionConnection
-function evalscript(conn::RedisConnection, script, numkeys::Integer, keys, args)
+function evalscript(conn::Union{RedisConnection,PipelineConnection,TransactionConnection}, script, numkeys::Integer, keys, args)
     response = execute_command(conn, flatten_command("eval", script, numkeys, keys, args))
     return response
 end


### PR DESCRIPTION
This augments `evalscript` to allow it on `PipelineConnection` and `TransactionConnection`.