### PR TITLE
feat: set hostname for SNI

### DIFF
--- a/src/transport/tls.jl
+++ b/src/transport/tls.jl
@@ -4,10 +4,16 @@ struct TLSTransport <: RedisTransport
     sslconfig::MbedTLS.SSLConfig
     buff::IOBuffer
 
-    function TLSTransport(sock::TCPSocket, sslconfig::MbedTLS.SSLConfig)
+    function TLSTransport(host::AbstractString, sock::TCPSocket, sslconfig::MbedTLS.SSLConfig)
         ctx = MbedTLS.SSLContext()
         MbedTLS.setup!(ctx, sslconfig)
         MbedTLS.associate!(ctx, sock)
+        # set hostname only if it's not an IP adress
+        try
+          parse(IPAddr, host)
+        catch x
+          MbedTLS.hostname!(ctx, host)
+        end
         MbedTLS.handshake(ctx)
 
         return new(sock, ctx, sslconfig, PipeBuffer())

--- a/src/transport/transport.jl
+++ b/src/transport/transport.jl
@@ -26,7 +26,7 @@ include("tcp.jl")
 
 function transport(host::AbstractString, port::Integer, sslconfig::Union{MbedTLS.SSLConfig, Nothing}=nothing)
     socket = connect(host, port)
-    return (sslconfig !== nothing) ? TLSTransport(socket, sslconfig) : TCPTransport(socket)
+    return (sslconfig !== nothing) ? TLSTransport(host, socket, sslconfig) : TCPTransport(socket)
 end
 
 end # module Transport


### PR DESCRIPTION
This pull request enhances **TLSTransport** to allow Server Name Identification (**SNI**) on server.

The `hostname` must be set in the `SSLContext` which is not available as a parameter on `RedisConnection`.

To reduce the changes introduced, I decided to forward the `host` given as a parameter to `transport` function to the call of `TLSTransport` and so added a `host` parameter to it also.

Then according to the **MbedTLS** documentation
- I do not set `hostname` if it was provided as an IPv4 or IPv6 address as it is unsupported.
- I set `hostname` otherwise as it is harmless even if **SNI** is not used
