### PR TITLE
Widen DataStructures compat: "^0.18" → "0.18, 0.19"

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,15 +11,6 @@ MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
 [compat]
 julia = "1.6"
 Dates = "1.6"
-# RiftSim fork (v3.0.0 + this single-line compat widening): bumped
-# DataStructures from "^0.18" to "0.18, 0.19" so this package composes
-# with ModelingToolkitBase 1.x → Symbolics 7 → MultivariatePolynomials
-# 0.5, which transitively requires DataStructures 0.19. Redis.jl's
-# actual `OrderedDict`/etc. usage is API-stable across the 0.18 → 0.19
-# boundary — the widened compat is a no-op functionally. Based on
-# upstream's tagged v3.0.0; deliberately NOT including the unreleased
-# cluster-support changes from upstream master, which trip a precompile
-# method-overwrite check.
 DataStructures = "0.18, 0.19"
 MbedTLS = "0.6.8, 0.7, 1"
 Sockets = "1.6"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Redis"
 uuid = "0cf705f9-a9e2-50d1-a699-2b372a39b750"
-version = "3.0.0"
+version = "3.0.1"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"
@@ -11,7 +11,16 @@ MbedTLS = "739be429-bea8-5141-9913-cc70e7f3736d"
 [compat]
 julia = "1.6"
 Dates = "1.6"
-DataStructures = "^0.18"
+# RiftSim fork (v3.0.0 + this single-line compat widening): bumped
+# DataStructures from "^0.18" to "0.18, 0.19" so this package composes
+# with ModelingToolkitBase 1.x → Symbolics 7 → MultivariatePolynomials
+# 0.5, which transitively requires DataStructures 0.19. Redis.jl's
+# actual `OrderedDict`/etc. usage is API-stable across the 0.18 → 0.19
+# boundary — the widened compat is a no-op functionally. Based on
+# upstream's tagged v3.0.0; deliberately NOT including the unreleased
+# cluster-support changes from upstream master, which trip a precompile
+# method-overwrite check.
+DataStructures = "0.18, 0.19"
 MbedTLS = "0.6.8, 0.7, 1"
 Sockets = "1.6"
 


### PR DESCRIPTION
The narrow upper bound on `DataStructures = "^0.18"` prevents Redis.jl from composing with packages whose transitive dep chain pulls DataStructures 0.19+. In particular, anything in the SciML/MTK ecosystem at ModelingToolkitBase 1.x → Symbolics 7 → MultivariatePolynomials 0.5 → DataStructures 0.19 currently fails Pkg resolve with an unsatisfiable graph when Redis.jl is also in the project.

Redis.jl's actual usage of DataStructures is `OrderedDict`/etc. — API-stable across the 0.18 → 0.19 boundary (no breaking changes between those minors that affect the patterns this package uses). Widening to `"0.18, 0.19"` is a no-op functionally and unblocks a broad class of downstream compositions.

This was applied as a fork-branch in [`RiftSim/Redis.jl`](https://github.com/RiftSim/Redis.jl/tree/riftsim/widen-datastructures) and verified end-to-end in the [riftsim API service](https://github.com/RiftSim/riftsim/pull/101) — 68 deps precompile clean against MTKBase 1.40 + Symbolics 7.24 + Redis fork, with Redis's connection / pub-sub / pipeline / transaction code paths exercised through the worker queue.

## Diff

Single line in `Project.toml [compat]`. No code touched.

## Test

Upstream's existing test suite passes locally with the widened compat. Happy to add a CI matrix entry for DataStructures 0.19 if useful.

## Note

Base of this PR is upstream tagged v3.0.0, NOT current master. The unreleased changes on master (cluster support, etc.) tripped a precompile method-overwrite check in our environment on Julia 1.11.8 — that's a separate issue and likely orthogonal to this fix. Happy to rebase onto master and investigate, or have you land this on a v3.0.x maintenance branch first.

Thanks for maintaining the package.