### PR TITLE
chore: set next release version to 3.1.0

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "Redis"
 uuid = "0cf705f9-a9e2-50d1-a699-2b372a39b750"
-version = "4.0.0"
+version = "3.1.0"
 
 [deps]
 DataStructures = "864edb3b-99cc-5e75-8d2d-829cb0a9cfe8"


### PR DESCRIPTION
Marking the version as 3.1.0 in Project.toml for tagging the next release. Since there are no breaking changes, we do not need to bump the major version.

Ref: https://github.com/JuliaDatabases/Redis.jl/issues/118